### PR TITLE
Expanded to query token balances for multiple addresses. 

### DIFF
--- a/lib/Utils.js
+++ b/lib/Utils.js
@@ -88,27 +88,38 @@ var Utils = /** @class */ (function () {
             });
         });
     };
-    // Retrieve token balances for a given address.
+    // Retrieve token balances for a given address or array of addresses.
     Utils.prototype.balancesForAddress = function (address) {
         return __awaiter(this, void 0, void 0, function () {
-            var path, response, error_2;
+            var path, response, path, response, error_2;
             return __generator(this, function (_a) {
                 switch (_a.label) {
                     case 0:
+                        _a.trys.push([0, 5, , 6]);
+                        if (!(typeof address === "string")) return [3 /*break*/, 2];
                         path = this.restURL + "slp/balancesForAddress/" + address;
-                        _a.label = 1;
-                    case 1:
-                        _a.trys.push([1, 3, , 4]);
                         return [4 /*yield*/, axios_1.default.get(path)];
+                    case 1:
+                        response = _a.sent();
+                        return [2 /*return*/, response.data
+                            // Array of addresses.
+                        ];
                     case 2:
+                        if (!Array.isArray(address)) return [3 /*break*/, 4];
+                        path = this.restURL + "slp/balancesForAddress";
+                        return [4 /*yield*/, axios_1.default.post(path, {
+                                addresses: address
+                            })];
+                    case 3:
                         response = _a.sent();
                         return [2 /*return*/, response.data];
-                    case 3:
+                    case 4: throw new Error("Input address must be a string or array of strings.");
+                    case 5:
                         error_2 = _a.sent();
                         if (error_2.response && error_2.response.data)
                             throw error_2.response.data;
                         throw error_2;
-                    case 4: return [2 /*return*/];
+                    case 6: return [2 /*return*/];
                 }
             });
         });

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -41,13 +41,29 @@ class Utils {
     }
   }
 
-  // Retrieve token balances for a given address.
-  async balancesForAddress(address: string): Promise<Object> {
-    const path: string = `${this.restURL}slp/balancesForAddress/${address}`
-
+  // Retrieve token balances for a given address or array of addresses.
+  async balancesForAddress(address: string | string[]): Promise<Object> {
     try {
-      const response = await axios.get(path)
-      return response.data
+      // Single address.
+      if (typeof address === "string") {
+        const path: string = `${this.restURL}slp/balancesForAddress/${address}`
+
+        const response = await axios.get(path)
+        return response.data
+
+        // Array of addresses.
+      } else if (Array.isArray(address)) {
+        const path: string = `${this.restURL}slp/balancesForAddress`
+
+        // Dev note: must use axios.post for unit test stubbing.
+        const response: any = await axios.post(path, {
+          addresses: address
+        })
+
+        return response.data
+      }
+
+      throw new Error(`Input address must be a string or array of strings.`)
     } catch (error) {
       if (error.response && error.response.data) throw error.response.data
       throw error

--- a/test/Utils.js
+++ b/test/Utils.js
@@ -154,6 +154,22 @@ describe("#Utils", () => {
   })
 
   describe("#balancesForAddress", () => {
+    it(`should throw an error if input is not a string or array of strings`, async () => {
+      try {
+        const address = 1234
+
+        await SLP.Utils.balancesForAddress(address)
+
+        assert2.equal(true, false, "Uh oh. Code path should not end here.")
+      } catch (err) {
+        //console.log(`Error: `, err)
+        assert2.include(
+          err.message,
+          `Input address must be a string or array of strings`
+        )
+      }
+    })
+
     it(`should fetch all balances for address: simpleledger:qzv3zz2trz0xgp6a96lu4m6vp2nkwag0kvyucjzqt9`, async () => {
       // Mock the call to rest.bitcoin.com
       if (process.env.TEST === "unit") {
@@ -161,9 +177,6 @@ describe("#Utils", () => {
           .stub(axios, "get")
           .resolves({ data: mockData.balancesForAddress })
       }
-      //sandbox
-      //  .stub(SLP.Utils, "balancesForAddress")
-      //  .resolves(mockData.balancesForAddress)
 
       const balances = await SLP.Utils.balancesForAddress(
         "simpleledger:qzv3zz2trz0xgp6a96lu4m6vp2nkwag0kvyucjzqt9"
@@ -172,6 +185,33 @@ describe("#Utils", () => {
 
       assert2.isArray(balances)
       assert2.hasAllKeys(balances[0], [
+        "tokenId",
+        "balanceString",
+        "balance",
+        "decimalCount",
+        "slpAddress"
+      ])
+    })
+
+    it(`should fetch balances for multiple addresses.`, async () => {
+      const addresses = [
+        "simpleledger:qzv3zz2trz0xgp6a96lu4m6vp2nkwag0kvyucjzqt9",
+        "simpleledger:qqss4zp80hn6szsa4jg2s9fupe7g5tcg5ucdyl3r57"
+      ]
+
+      // Mock the call to rest.bitcoin.com
+      if (process.env.TEST === "unit") {
+        sandbox
+          .stub(axios, "get")
+          .resolves({ data: mockData.balancesForAddresses })
+      }
+
+      const balances = await SLP.Utils.balancesForAddress(addresses)
+      //console.log(`balances: ${JSON.stringify(balances, null, 2)}`)
+
+      assert2.isArray(balances)
+      assert2.isArray(balances[0])
+      assert2.hasAllKeys(balances[0][0], [
         "tokenId",
         "balanceString",
         "balance",

--- a/test/fixtures/mock-utils.js
+++ b/test/fixtures/mock-utils.js
@@ -134,6 +134,37 @@ const balancesForAddress = [
   }
 ]
 
+const balancesForAddresses = [
+  [
+    {
+      tokenId:
+        "df808a41672a0a0ae6475b44f272a107bc9961b90f29dc918d71301f24fe92fb",
+      balance: 1,
+      balanceString: "1",
+      slpAddress: "simpleledger:qzv3zz2trz0xgp6a96lu4m6vp2nkwag0kvyucjzqt9",
+      decimalCount: 8
+    },
+    {
+      tokenId:
+        "a436c8e1b6bee3d701c6044d190f76f774be83c36de8d34a988af4489e86dd37",
+      balance: 1,
+      balanceString: "1",
+      slpAddress: "simpleledger:qzv3zz2trz0xgp6a96lu4m6vp2nkwag0kvyucjzqt9",
+      decimalCount: 7
+    }
+  ],
+  [
+    {
+      tokenId:
+        "497291b8a1dfe69c8daea50677a3d31a5ef0e9484d8bebb610dac64bbc202fb7",
+      balance: 10,
+      balanceString: "10",
+      slpAddress: "simpleledger:qqss4zp80hn6szsa4jg2s9fupe7g5tcg5ucdyl3r57",
+      decimalCount: 8
+    }
+  ]
+]
+
 const mockBalance = {
   tokenId: "df808a41672a0a0ae6475b44f272a107bc9961b90f29dc918d71301f24fe92fb",
   balance: 1,
@@ -226,6 +257,7 @@ module.exports = {
   mockToken,
   mockTokens,
   balancesForAddress,
+  balancesForAddresses,
   mockRawTx,
   mockIsValidTxid,
   mockBalancesForToken,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1135,13 +1135,13 @@ bip-schnorr@^0.3.0:
     random-bytes "^1.0.0"
     safe-buffer "^5.0.1"
 
-"bip21@github:Bitcoin-com/bip21":
+bip21@Bitcoin-com/bip21:
   version "2.0.1"
   resolved "https://codeload.github.com/Bitcoin-com/bip21/tar.gz/28f8d03a3a16ed11eb5b963248ed1be8c46c6d6f"
   dependencies:
     qs "^6.3.0"
 
-"bip32-utils@github:Bitcoin-com/bip32-utils#0.13.1":
+bip32-utils@Bitcoin-com/bip32-utils#0.13.1:
   version "0.13.1"
   resolved "https://codeload.github.com/Bitcoin-com/bip32-utils/tar.gz/b8a33ebd0a0ac39de7cd987e5c3f77a8c5d84e58"
   dependencies:
@@ -1215,11 +1215,11 @@ bitbox-sdk@8.7.0:
     socket.io-client "^2.2.0"
     wif "^2.0.6"
 
-bitcoincash-ops@Bitcoin-com/bitcoincash-ops#2.0.0, "bitcoincash-ops@github:Bitcoin-com/bitcoincash-ops#2.0.0":
+bitcoincash-ops@Bitcoin-com/bitcoincash-ops#2.0.0:
   version "2.0.0"
   resolved "https://codeload.github.com/Bitcoin-com/bitcoincash-ops/tar.gz/6ab82cc7326c67236f3b2d9d0457258ac2ef48e3"
 
-"bitcoincashjs-lib@github:Bitcoin-com/bitcoincashjs-lib#v4.0.1":
+bitcoincashjs-lib@Bitcoin-com/bitcoincashjs-lib#v4.0.1:
   version "4.0.1"
   resolved "https://codeload.github.com/Bitcoin-com/bitcoincashjs-lib/tar.gz/28447b40a4ccd23913f7ade6589dc7214c99e60a"
   dependencies:
@@ -1943,7 +1943,7 @@ code-point-at@^1.0.0:
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
   integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
 
-"coininfo@github:Bitcoin-com/coininfo":
+coininfo@Bitcoin-com/coininfo:
   version "4.0.0"
   resolved "https://codeload.github.com/Bitcoin-com/coininfo/tar.gz/eece2c6141d08c3e7783929f2a1e1e681aa1a82c"
   dependencies:


### PR DESCRIPTION
This PR expands `Utils.balancesForAddress()` to accept an array of addresses. It makes use of rest.bitcoin.com POST/bulk endpoint. This PR also includes additional unit tests.