### PR TITLE
tokenUtxoDetails()

### DIFF
--- a/lib/Util.js
+++ b/lib/Util.js
@@ -500,16 +500,6 @@ var Util = /** @class */ (function (_super) {
                                             // If there are no vout matches, the UTXO can safely be marked as false.
                                             if (voutMatch.length === 0)
                                                 validations[i] = false;
-                                            // // Loop through the spendData array.
-                                            // for (let j = 0; j < slpData.spendData.length; j++) {
-                                            //   const thisVout = slpData.spendData[j].vout
-                                            //
-                                            //   // Assume false to start.
-                                            //   validations[i] = false
-                                            //
-                                            //   // UTXO vout value should match if it's truely an SLP UTXO.
-                                            //   if (thisUtxo.vout === thisVout) validations[i] = true
-                                            // }
                                         }
                                         _a.label = 2;
                                     case 2: return [2 /*return*/];
@@ -534,6 +524,143 @@ var Util = /** @class */ (function (_super) {
                         if (error_10.response && error_10.response.data)
                             throw error_10.response.data;
                         throw error_10;
+                    case 7: return [2 /*return*/];
+                }
+            });
+        });
+    };
+    // Hydrate a UTXO with SLP token metadata.
+    //
+    // Expects an array of UTXO objects as input. Returns an array of equal size.
+    // If the UTXO does not belong to a SLP transaction, it will return false.
+    // If the UTXO is part of an SLP transaction, it will return the UTXO object
+    // with additional SLP information attached.
+    Util.prototype.tokenUtxoDetails = function (utxos) {
+        return __awaiter(this, void 0, void 0, function () {
+            var i, thisUtxo, txids, validations, _loop_2, this_2, i, error_11;
+            return __generator(this, function (_a) {
+                switch (_a.label) {
+                    case 0:
+                        _a.trys.push([0, 6, , 7]);
+                        // Throw error if input is not an array.
+                        if (!Array.isArray(utxos))
+                            throw new Error("Input must be an array.");
+                        // Loop through each element in the array and validate the input before
+                        // further processing.
+                        for (i = 0; i < utxos.length; i++) {
+                            thisUtxo = utxos[i];
+                            // Throw error if utxo does not have a satoshis property.
+                            if (!thisUtxo.satoshis)
+                                throw new Error("utxo " + i + " does not have a satoshis property.");
+                            // Throw error if utxo does not have a txid property.
+                            if (!thisUtxo.txid)
+                                throw new Error("utxo " + i + " does not have a txid property.");
+                        }
+                        txids = utxos.map(function (x) { return x.txid; });
+                        return [4 /*yield*/, this.validateTxid(txids)
+                            // console.log(`validations: ${JSON.stringify(validations, null, 2)}`)
+                            // Extract the boolean result
+                        ];
+                    case 1:
+                        validations = _a.sent();
+                        // console.log(`validations: ${JSON.stringify(validations, null, 2)}`)
+                        // Extract the boolean result
+                        validations = validations.map(function (x) { return x.valid; });
+                        _loop_2 = function (i) {
+                            var thisValidation, thisUtxo, slpData, voutMatch, genesisData;
+                            return __generator(this, function (_a) {
+                                switch (_a.label) {
+                                    case 0:
+                                        thisValidation = validations[i];
+                                        thisUtxo = utxos[i];
+                                        if (!thisValidation) return [3 /*break*/, 4];
+                                        return [4 /*yield*/, this_2.decodeOpReturn(thisUtxo.txid)
+                                            // console.log(`slpData: ${JSON.stringify(slpData, null, 2)}`)
+                                            // Handle Genesis SLP transactions.
+                                        ];
+                                    case 1:
+                                        slpData = _a.sent();
+                                        // console.log(`slpData: ${JSON.stringify(slpData, null, 2)}`)
+                                        // Handle Genesis SLP transactions.
+                                        if (slpData.transactionType === "genesis") {
+                                            if (thisUtxo.vout !== slpData.mintBatonVout && // UTXO is not a mint baton output.
+                                                thisUtxo.vout !== 1 // UTXO is not the reciever of the genesis or mint tokens.
+                                            ) {
+                                                // Can safely be marked as false.
+                                                validations[i] = false;
+                                            }
+                                            // If this is a valid SLP UTXO, then return the decoded OP_RETURN data.
+                                            else {
+                                                thisUtxo.tokenType = "minting-baton";
+                                                thisUtxo.tokenId = thisUtxo.txid;
+                                                thisUtxo.tokenTicker = slpData.ticker;
+                                                thisUtxo.tokenName = slpData.name;
+                                                thisUtxo.tokenDocumentUrl = slpData.documentUrl;
+                                                thisUtxo.tokenDocumentHash = slpData.documentHash;
+                                                thisUtxo.decimals = slpData.decimals;
+                                                // something
+                                                validations[i] = thisUtxo;
+                                            }
+                                        }
+                                        // Handle Mint SLP transactions.
+                                        if (slpData.transactionType === "mint") {
+                                            if (thisUtxo.vout !== slpData.mintBatonVout && // UTXO is not a mint baton output.
+                                                thisUtxo.vout !== 1 // UTXO is not the reciever of the genesis or mint tokens.
+                                            )
+                                                // Can safely be marked as false.
+                                                validations[i] = false;
+                                        }
+                                        if (!(slpData.transactionType === "send")) return [3 /*break*/, 4];
+                                        voutMatch = slpData.spendData.filter(function (x) { return thisUtxo.vout === x.vout; });
+                                        if (!(voutMatch.length === 0)) return [3 /*break*/, 2];
+                                        validations[i] = false;
+                                        return [3 /*break*/, 4];
+                                    case 2: return [4 /*yield*/, this_2.decodeOpReturn(slpData.tokenId)
+                                        // console.log(
+                                        //   `genesisData: ${JSON.stringify(genesisData, null, 2)}`
+                                        // )
+                                        // Hydrate the UTXO object with information about the SLP token.
+                                    ];
+                                    case 3:
+                                        genesisData = _a.sent();
+                                        // console.log(
+                                        //   `genesisData: ${JSON.stringify(genesisData, null, 2)}`
+                                        // )
+                                        // Hydrate the UTXO object with information about the SLP token.
+                                        thisUtxo.utxoType = "token";
+                                        thisUtxo.tokenId = slpData.tokenId;
+                                        thisUtxo.tokenTicker = genesisData.ticker;
+                                        thisUtxo.tokenName = genesisData.name;
+                                        thisUtxo.tokenDocumentUrl = genesisData.documentUrl;
+                                        thisUtxo.tokenDocumentHash = genesisData.documentHash;
+                                        thisUtxo.decimals = genesisData.decimals;
+                                        // Calculate the real token quantity.
+                                        thisUtxo.tokenQty =
+                                            voutMatch[0].quantity / Math.pow(10, thisUtxo.decimals);
+                                        validations[i] = thisUtxo;
+                                        _a.label = 4;
+                                    case 4: return [2 /*return*/];
+                                }
+                            });
+                        };
+                        this_2 = this;
+                        i = 0;
+                        _a.label = 2;
+                    case 2:
+                        if (!(i < utxos.length)) return [3 /*break*/, 5];
+                        return [5 /*yield**/, _loop_2(i)];
+                    case 3:
+                        _a.sent();
+                        _a.label = 4;
+                    case 4:
+                        i++;
+                        return [3 /*break*/, 2];
+                    case 5: return [2 /*return*/, validations];
+                    case 6:
+                        error_11 = _a.sent();
+                        if (error_11.response && error_11.response.data)
+                            throw error_11.response.data;
+                        throw error_11;
                     case 7: return [2 /*return*/];
                 }
             });

--- a/test/Utils.js
+++ b/test/Utils.js
@@ -708,4 +708,251 @@ describe("#Utils", () => {
       assert.equal(data[0], true, "Simple send UTXO correctly identified")
     })
   })
+
+  describe("#tokenUtxoDetails", () => {
+    it("should throw error if input is not an array.", async () => {
+      try {
+        await SLP.Utils.tokenUtxoDetails("test")
+
+        assert2.equal(true, false, "Unexpected result.")
+      } catch (err) {
+        assert2.include(
+          err.message,
+          `Input must be an array`,
+          "Expected error message."
+        )
+      }
+    })
+
+    it("should throw error if utxo does not have satoshis property.", async () => {
+      try {
+        const utxos = [
+          {
+            txid:
+              "bd158c564dd4ef54305b14f44f8e94c44b649f246dab14bcb42fb0d0078b8a90",
+            vout: 3,
+            amount: 0.00002015,
+            satoshis: 2015,
+            height: 594892,
+            confirmations: 5
+          },
+          {
+            txid:
+              "bd158c564dd4ef54305b14f44f8e94c44b649f246dab14bcb42fb0d0078b8a90",
+            vout: 2,
+            amount: 0.00000546,
+            height: 594892,
+            confirmations: 5
+          }
+        ]
+
+        await SLP.Utils.tokenUtxoDetails(utxos)
+
+        assert2.equal(true, false, "Unexpected result.")
+      } catch (err) {
+        assert2.include(
+          err.message,
+          `utxo 1 does not have a satoshis property`,
+          "Expected error message."
+        )
+      }
+    })
+
+    it("should throw error if utxo does not have txid property.", async () => {
+      try {
+        const utxos = [
+          {
+            txid:
+              "bd158c564dd4ef54305b14f44f8e94c44b649f246dab14bcb42fb0d0078b8a90",
+            vout: 3,
+            amount: 0.00002015,
+            satoshis: 2015,
+            height: 594892,
+            confirmations: 5
+          },
+          {
+            vout: 2,
+            amount: 0.00000546,
+            satoshis: 546,
+            height: 594892,
+            confirmations: 5
+          }
+        ]
+
+        await SLP.Utils.tokenUtxoDetails(utxos)
+
+        assert2.equal(true, false, "Unexpected result.")
+      } catch (err) {
+        assert2.include(
+          err.message,
+          `utxo 1 does not have a txid property`,
+          "Expected error message."
+        )
+      }
+    })
+
+    // This captures an important corner-case. When an SLP token is created, the
+    // change UTXO will contain the same SLP txid, but it is not an SLP UTXO.
+    it("should return details on minting baton from genesis transaction", async () => {
+      // Mock the call to REST API
+      if (process.env.TEST === "unit") {
+        // Stub the call to validateTxid
+        sandbox.stub(SLP.Utils, "validateTxid").resolves([
+          {
+            txid:
+              "bd158c564dd4ef54305b14f44f8e94c44b649f246dab14bcb42fb0d0078b8a90",
+            valid: true
+          },
+          {
+            txid:
+              "bd158c564dd4ef54305b14f44f8e94c44b649f246dab14bcb42fb0d0078b8a90",
+            valid: true
+          }
+        ])
+
+        // Stub the calls to decodeOpReturn.
+        sandbox.stub(SLP.Utils, "decodeOpReturn").resolves({
+          tokenType: 1,
+          transactionType: "genesis",
+          ticker: "SLPSDK",
+          name: "SLP SDK example using BITBOX",
+          documentUrl: "developer.bitcoin.com",
+          documentHash: "",
+          decimals: 8,
+          mintBatonVout: 2,
+          initialQty: 507,
+          tokensSentTo:
+            "bitcoincash:qpcqs0n5xap26un2828n55gan2ylj7wavvzeuwdx05",
+          batonHolder: "bitcoincash:qpcqs0n5xap26un2828n55gan2ylj7wavvzeuwdx05"
+        })
+      }
+
+      const utxos = [
+        {
+          txid:
+            "bd158c564dd4ef54305b14f44f8e94c44b649f246dab14bcb42fb0d0078b8a90",
+          vout: 3,
+          amount: 0.00002015,
+          satoshis: 2015,
+          height: 594892,
+          confirmations: 5
+        },
+        {
+          txid:
+            "bd158c564dd4ef54305b14f44f8e94c44b649f246dab14bcb42fb0d0078b8a90",
+          vout: 2,
+          amount: 0.00000546,
+          satoshis: 546,
+          height: 594892,
+          confirmations: 5
+        }
+      ]
+
+      const data = await SLP.Utils.tokenUtxoDetails(utxos)
+      //console.log(`data: ${JSON.stringify(data, null, 2)}`)
+
+      assert2.equal(data[0], false, "Change UTXO marked as false.")
+      assert2.hasAnyKeys(data[1], [
+        "txid",
+        "vout",
+        "amount",
+        "satoshis",
+        "height",
+        "confirmations",
+        "tokenType",
+        "tokenId",
+        "tokenTicker",
+        "tokenName",
+        "tokenDocumentUrl",
+        "tokenDocumentHash",
+        "decimals"
+      ])
+    })
+
+    it("should return details for a simple SEND SLP token utxo", async () => {
+      // Mock the call to REST API
+      if (process.env.TEST === "unit") {
+        // Stub the call to validateTxid
+        sandbox.stub(SLP.Utils, "validateTxid").resolves([
+          {
+            txid:
+              "fde117b1f176b231e2fa9a6cb022e0f7c31c288221df6bcb05f8b7d040ca87cb",
+            valid: true
+          }
+        ])
+
+        // Stub the calls to decodeOpReturn.
+        sandbox
+          .stub(SLP.Utils, "decodeOpReturn")
+          .onCall(0)
+          .resolves({
+            tokenType: 1,
+            transactionType: "send",
+            tokenId:
+              "497291b8a1dfe69c8daea50677a3d31a5ef0e9484d8bebb610dac64bbc202fb7",
+            spendData: [
+              {
+                quantity: "200000000",
+                sentTo:
+                  "bitcoincash:qqll3st8xl0k8cgv8dgrrrkntv6hqdn8huv3xm2ztf",
+                vout: 1
+              },
+              {
+                quantity: "99887500000000",
+                sentTo:
+                  "bitcoincash:qzv7t2pzn2d0pklnetdjt65crh6fe8vnhuwvhsk2nn",
+                vout: 2
+              }
+            ]
+          })
+          .onCall(1)
+          .resolves({
+            tokenType: 1,
+            transactionType: "genesis",
+            ticker: "TOK-CH",
+            name: "TokyoCash",
+            documentUrl: "",
+            documentHash: "",
+            decimals: 8,
+            mintBatonVout: 0,
+            initialQty: 21000000,
+            tokensSentTo:
+              "bitcoincash:qqtuq6rzdgggt2mc9w20u4thkeaez69pmy6ur897sr",
+            batonHolder: "NEVER_CREATED"
+          })
+      }
+
+      const utxos = [
+        {
+          txid:
+            "fde117b1f176b231e2fa9a6cb022e0f7c31c288221df6bcb05f8b7d040ca87cb",
+          vout: 1,
+          amount: 0.00000546,
+          satoshis: 546,
+          height: 596089,
+          confirmations: 748
+        }
+      ]
+
+      const data = await SLP.Utils.tokenUtxoDetails(utxos)
+      //console.log(`data: ${JSON.stringify(data, null, 2)}`)
+
+      assert2.hasAnyKeys(data[0], [
+        "txid",
+        "vout",
+        "amount",
+        "satoshis",
+        "height",
+        "confirmations",
+        "utxoType",
+        "tokenId",
+        "tokenTicker",
+        "tokenName",
+        "tokenDocumentUrl",
+        "tokenDocumentHash",
+        "decimals",
+        "tokenQty"
+      ])
+    })
+  })
 })


### PR DESCRIPTION
A convenience function for the `SLP.Util` class. Taken an array of UTXO data as input and hydrates it with token metadata. This makes it very easy for wallets to determine if a UTXO is safe to spend as BCH, or if it belongs to a SLP token.

Here is an example output for a UTXO belonging to a simple-send SLP transaction:
```
{
 "txid": "fde117b1f176b231e2fa9a6cb022e0f7c31c288221df6bcb05f8b7d040ca87cb",
 "vout": 1,
 "amount": 0.00000546,
 "satoshis": 546,
 "height": 596089,
 "confirmations": 748,
 "utxoType": "token",
 "tokenId": "497291b8a1dfe69c8daea50677a3d31a5ef0e9484d8bebb610dac64bbc202fb7",
 "tokenTicker": "TOK-CH",
 "tokenName": "TokyoCash",
 "tokenDocumentUrl": "",
 "tokenDocumentHash": "",
 "decimals": 8,
 "tokenQty": 2
}
```