### PR TITLE
Fixing SLP.Utils.tokenUtxoDetails() for mint transactions

### DIFF
--- a/lib/Util.js
+++ b/lib/Util.js
@@ -375,10 +375,19 @@ var Util = /** @class */ (function (_super) {
                             outObj.transactionType = "mint";
                             outObj.tokenId = script[4];
                             mintBatonVout = 0;
+                            // Dev note: Haven't seen this if-statement in the wild. Copied from
+                            // Badger Wallet code.
                             if (typeof script[5] === "string" && script[5].startsWith("OP_"))
                                 mintBatonVout = parseInt(script[5].slice(3));
+                            // This is the common use case with slp-sdk examples.
+                            else
+                                mintBatonVout = parseInt(script[5]);
                             outObj.mintBatonVout = mintBatonVout;
                             // Check if baton was passed or destroyed.
+                            // Dev Note: There should be some more extensive checking here. The most
+                            // common way of 'burning' the minting baton is to set script[5] to a
+                            // value of 0, but it could also point to a non-existant vout.
+                            // TODO: Add checking if script[5] refers to a non-existant vout.
                             outObj.batonStillExists = false; // false by default.
                             if (mintBatonVout > 1)
                                 outObj.batonStillExists = true;
@@ -567,13 +576,13 @@ var Util = /** @class */ (function (_super) {
                         // Extract the boolean result
                         validations = validations.map(function (x) { return x.valid; });
                         _loop_2 = function (i) {
-                            var thisValidation, thisUtxo, slpData, voutMatch, genesisData;
+                            var thisValidation, thisUtxo, slpData, genesisData, voutMatch, genesisData;
                             return __generator(this, function (_a) {
                                 switch (_a.label) {
                                     case 0:
                                         thisValidation = validations[i];
                                         thisUtxo = utxos[i];
-                                        if (!thisValidation) return [3 /*break*/, 4];
+                                        if (!thisValidation) return [3 /*break*/, 7];
                                         return [4 /*yield*/, this_2.decodeOpReturn(thisUtxo.txid)
                                             // console.log(`slpData: ${JSON.stringify(slpData, null, 2)}`)
                                             // Handle Genesis SLP transactions.
@@ -602,26 +611,47 @@ var Util = /** @class */ (function (_super) {
                                                 validations[i] = thisUtxo;
                                             }
                                         }
-                                        // Handle Mint SLP transactions.
-                                        if (slpData.transactionType === "mint") {
-                                            if (thisUtxo.vout !== slpData.mintBatonVout && // UTXO is not a mint baton output.
-                                                thisUtxo.vout !== 1 // UTXO is not the reciever of the genesis or mint tokens.
-                                            )
-                                                // Can safely be marked as false.
-                                                validations[i] = false;
-                                        }
-                                        if (!(slpData.transactionType === "send")) return [3 /*break*/, 4];
-                                        voutMatch = slpData.spendData.filter(function (x) { return thisUtxo.vout === x.vout; });
-                                        if (!(voutMatch.length === 0)) return [3 /*break*/, 2];
+                                        if (!(slpData.transactionType === "mint")) return [3 /*break*/, 4];
+                                        if (!(thisUtxo.vout !== slpData.mintBatonVout && // UTXO is not a mint baton output.
+                                            thisUtxo.vout !== 1) // UTXO is not the reciever of the genesis or mint tokens.
+                                        ) return [3 /*break*/, 2]; // UTXO is not the reciever of the genesis or mint tokens.
+                                        // Can safely be marked as false.
                                         validations[i] = false;
                                         return [3 /*break*/, 4];
                                     case 2: return [4 /*yield*/, this_2.decodeOpReturn(slpData.tokenId)
+                                        // Hydrate the UTXO object with information about the SLP token.
+                                    ];
+                                    case 3:
+                                        genesisData = _a.sent();
+                                        // Hydrate the UTXO object with information about the SLP token.
+                                        thisUtxo.utxoType = "token";
+                                        thisUtxo.transactionType = "mint";
+                                        thisUtxo.tokenId = slpData.tokenId;
+                                        thisUtxo.tokenTicker = genesisData.ticker;
+                                        thisUtxo.tokenName = genesisData.name;
+                                        thisUtxo.tokenDocumentUrl = genesisData.documentUrl;
+                                        thisUtxo.tokenDocumentHash = genesisData.documentHash;
+                                        thisUtxo.decimals = genesisData.decimals;
+                                        thisUtxo.mintBatonVout = slpData.mintBatonVout;
+                                        thisUtxo.batonStillExists = slpData.batonStillExists;
+                                        // Calculate the real token quantity.
+                                        thisUtxo.tokenQty =
+                                            slpData.quantity / Math.pow(10, thisUtxo.decimals);
+                                        validations[i] = thisUtxo;
+                                        _a.label = 4;
+                                    case 4:
+                                        if (!(slpData.transactionType === "send")) return [3 /*break*/, 7];
+                                        voutMatch = slpData.spendData.filter(function (x) { return thisUtxo.vout === x.vout; });
+                                        if (!(voutMatch.length === 0)) return [3 /*break*/, 5];
+                                        validations[i] = false;
+                                        return [3 /*break*/, 7];
+                                    case 5: return [4 /*yield*/, this_2.decodeOpReturn(slpData.tokenId)
                                         // console.log(
                                         //   `genesisData: ${JSON.stringify(genesisData, null, 2)}`
                                         // )
                                         // Hydrate the UTXO object with information about the SLP token.
                                     ];
-                                    case 3:
+                                    case 6:
                                         genesisData = _a.sent();
                                         // console.log(
                                         //   `genesisData: ${JSON.stringify(genesisData, null, 2)}`
@@ -638,8 +668,8 @@ var Util = /** @class */ (function (_super) {
                                         thisUtxo.tokenQty =
                                             voutMatch[0].quantity / Math.pow(10, thisUtxo.decimals);
                                         validations[i] = thisUtxo;
-                                        _a.label = 4;
-                                    case 4: return [2 /*return*/];
+                                        _a.label = 7;
+                                    case 7: return [2 /*return*/];
                                 }
                             });
                         };

--- a/test/Utils.js
+++ b/test/Utils.js
@@ -978,5 +978,86 @@ describe("#Utils", () => {
         "tokenQty"
       ])
     })
+
+    it("should return details for a MINT token utxo", async () => {
+      // Mock the call to REST API
+      if (process.env.TEST === "unit") {
+        // Stub the call to validateTxid
+        sandbox.stub(SLP.Utils, "validateTxid").resolves([
+          {
+            txid:
+              "cf4b922d1e1aa56b52d752d4206e1448ea76c3ebe69b3b97d8f8f65413bd5c76",
+            valid: true
+          }
+        ])
+
+        // Stub the calls to decodeOpReturn.
+        sandbox
+          .stub(SLP.Utils, "decodeOpReturn")
+          .onCall(0)
+          .resolves({
+            tokenType: 1,
+            transactionType: "mint",
+            tokenId:
+              "38e97c5d7d3585a2cbf3f9580c82ca33985f9cb0845d4dcce220cb709f9538b0",
+            mintBatonVout: 2,
+            batonStillExists: true,
+            quantity: "1000000000000",
+            tokensSentTo:
+              "bitcoincash:qpszr2za8hht020trekw4jc9kar2v7jva5xej5uqns"
+          })
+          .onCall(1)
+          .resolves({
+            tokenType: 1,
+            transactionType: "genesis",
+            ticker: "PSF",
+            name: "Permissionless Software Foundation",
+            documentUrl: "psfoundation.cash",
+            documentHash: "",
+            decimals: 8,
+            mintBatonVout: 2,
+            initialQty: 19882.09163133,
+            tokensSentTo:
+              "bitcoincash:qpgeu2kvk4assnj3klez6yv8z2mv6q9vdy48m62vhn",
+            batonHolder:
+              "bitcoincash:qpgeu2kvk4assnj3klez6yv8z2mv6q9vdy48m62vhn"
+          })
+      }
+
+      const utxos = [
+        {
+          txid:
+            "cf4b922d1e1aa56b52d752d4206e1448ea76c3ebe69b3b97d8f8f65413bd5c76",
+          vout: 1,
+          amount: 0.00000546,
+          satoshis: 546,
+          height: 600297,
+          confirmations: 76
+        }
+      ]
+
+      const data = await SLP.Utils.tokenUtxoDetails(utxos)
+      // console.log(`data: ${JSON.stringify(data, null, 2)}`)
+
+      assert2.hasAnyKeys(data[0], [
+        "txid",
+        "vout",
+        "amount",
+        "satoshis",
+        "height",
+        "confirmations",
+        "utxoType",
+        "transactionType",
+        "tokenId",
+        "tokenTicker",
+        "tokenName",
+        "tokenDocumentUrl",
+        "tokenDocumentHash",
+        "decimals",
+        "mintBatonVout",
+        "batonStillExists",
+        "tokenQty"
+      ])
+    })
   })
 })


### PR DESCRIPTION
SLP UTXOs for mint transactions were not being interpreted correctly. This PR fixes the issue and adds a unit test case to ensure the fix stays in place.