### PR TITLE
tokenUtxoDetails: fixed bug where UTXO array elems would switch

### DIFF
--- a/lib/Address.js
+++ b/lib/Address.js
@@ -13,10 +13,11 @@ var __extends = (this && this.__extends) || (function () {
     };
 })();
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
         function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
         function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };

--- a/lib/SLPDB.js
+++ b/lib/SLPDB.js
@@ -1,9 +1,10 @@
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
         function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
         function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };

--- a/lib/TokenType1.js
+++ b/lib/TokenType1.js
@@ -1,9 +1,10 @@
 "use strict";
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
         function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
         function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };

--- a/lib/Util.js
+++ b/lib/Util.js
@@ -13,10 +13,11 @@ var __extends = (this && this.__extends) || (function () {
     };
 })();
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
         function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
         function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
@@ -546,7 +547,7 @@ var Util = /** @class */ (function (_super) {
     // with additional SLP information attached.
     Util.prototype.tokenUtxoDetails = function (utxos) {
         return __awaiter(this, void 0, void 0, function () {
-            var i, thisUtxo, txids, validations, _loop_2, this_2, i, error_11;
+            var i, thisUtxo, txids, validations, outAry, _loop_2, this_2, i, error_11;
             return __generator(this, function (_a) {
                 switch (_a.label) {
                     case 0:
@@ -568,21 +569,26 @@ var Util = /** @class */ (function (_super) {
                         txids = utxos.map(function (x) { return x.txid; });
                         return [4 /*yield*/, this.validateTxid(txids)
                             // console.log(`validations: ${JSON.stringify(validations, null, 2)}`)
-                            // Extract the boolean result
                         ];
                     case 1:
                         validations = _a.sent();
-                        // console.log(`validations: ${JSON.stringify(validations, null, 2)}`)
-                        // Extract the boolean result
-                        validations = validations.map(function (x) { return x.valid; });
+                        outAry = [] // Output Array
+                        ;
                         _loop_2 = function (i) {
-                            var thisValidation, thisUtxo, slpData, genesisData, voutMatch, genesisData;
+                            var thisUtxo, thisValidation, slpData, genesisData, voutMatch, genesisData;
                             return __generator(this, function (_a) {
                                 switch (_a.label) {
                                     case 0:
-                                        thisValidation = validations[i];
                                         thisUtxo = utxos[i];
-                                        if (!thisValidation) return [3 /*break*/, 7];
+                                        thisValidation = validations.filter(function (x) { return x.txid === thisUtxo.txid; });
+                                        // console.log(
+                                        //   `thisValidation: ${JSON.stringify(thisValidation, null, 2)}`
+                                        // )
+                                        // If the utxo is not SLP, then skip the loop.
+                                        if (!thisValidation[0].valid) {
+                                            outAry[i] = false;
+                                            return [2 /*return*/, "continue"];
+                                        }
                                         return [4 /*yield*/, this_2.decodeOpReturn(thisUtxo.txid)
                                             // console.log(`slpData: ${JSON.stringify(slpData, null, 2)}`)
                                             // Handle Genesis SLP transactions.
@@ -596,7 +602,7 @@ var Util = /** @class */ (function (_super) {
                                                 thisUtxo.vout !== 1 // UTXO is not the reciever of the genesis or mint tokens.
                                             ) {
                                                 // Can safely be marked as false.
-                                                validations[i] = false;
+                                                outAry[i] = false;
                                             }
                                             // If this is a valid SLP UTXO, then return the decoded OP_RETURN data.
                                             else {
@@ -608,7 +614,7 @@ var Util = /** @class */ (function (_super) {
                                                 thisUtxo.tokenDocumentHash = slpData.documentHash;
                                                 thisUtxo.decimals = slpData.decimals;
                                                 // something
-                                                validations[i] = thisUtxo;
+                                                outAry[i] = thisUtxo;
                                             }
                                         }
                                         if (!(slpData.transactionType === "mint")) return [3 /*break*/, 4];
@@ -616,7 +622,7 @@ var Util = /** @class */ (function (_super) {
                                             thisUtxo.vout !== 1) // UTXO is not the reciever of the genesis or mint tokens.
                                         ) return [3 /*break*/, 2]; // UTXO is not the reciever of the genesis or mint tokens.
                                         // Can safely be marked as false.
-                                        validations[i] = false;
+                                        outAry[i] = false;
                                         return [3 /*break*/, 4];
                                     case 2: return [4 /*yield*/, this_2.decodeOpReturn(slpData.tokenId)
                                         // Hydrate the UTXO object with information about the SLP token.
@@ -637,13 +643,13 @@ var Util = /** @class */ (function (_super) {
                                         // Calculate the real token quantity.
                                         thisUtxo.tokenQty =
                                             slpData.quantity / Math.pow(10, thisUtxo.decimals);
-                                        validations[i] = thisUtxo;
+                                        outAry[i] = thisUtxo;
                                         _a.label = 4;
                                     case 4:
                                         if (!(slpData.transactionType === "send")) return [3 /*break*/, 7];
                                         voutMatch = slpData.spendData.filter(function (x) { return thisUtxo.vout === x.vout; });
                                         if (!(voutMatch.length === 0)) return [3 /*break*/, 5];
-                                        validations[i] = false;
+                                        outAry[i] = false;
                                         return [3 /*break*/, 7];
                                     case 5: return [4 /*yield*/, this_2.decodeOpReturn(slpData.tokenId)
                                         // console.log(
@@ -667,7 +673,7 @@ var Util = /** @class */ (function (_super) {
                                         // Calculate the real token quantity.
                                         thisUtxo.tokenQty =
                                             voutMatch[0].quantity / Math.pow(10, thisUtxo.decimals);
-                                        validations[i] = thisUtxo;
+                                        outAry[i] = thisUtxo;
                                         _a.label = 7;
                                     case 7: return [2 /*return*/];
                                 }
@@ -685,7 +691,7 @@ var Util = /** @class */ (function (_super) {
                     case 4:
                         i++;
                         return [3 /*break*/, 2];
-                    case 5: return [2 /*return*/, validations];
+                    case 5: return [2 /*return*/, outAry];
                     case 6:
                         error_11 = _a.sent();
                         if (error_11.response && error_11.response.data)

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "mkdirp": "^0.5.1",
     "node-emoji": "^1.8.1",
     "repl.history": "^0.1.4",
-    "slpjs": "0.22.0",
+    "slpjs": "^0.23.0",
     "touch": "^3.1.0"
   },
   "devDependencies": {

--- a/test/Utils.js
+++ b/test/Utils.js
@@ -1061,6 +1061,63 @@ describe("#Utils", () => {
     })
 
     it("should process problematic utxos", async () => {
+      // Mock the call to REST API
+      if (process.env.TEST === "unit") {
+        // Stub the call to validateTxid
+        sandbox.stub(SLP.Utils, "validateTxid").resolves([
+          {
+            txid:
+              "67fd3c7c3a6eb0fea9ab311b91039545086220f7eeeefa367fa28e6e43009f19",
+            valid: true
+          },
+          {
+            txid:
+              "0e3a217fc22612002031d317b4cecd9b692b66b52951a67b23c43041aefa3959",
+            valid: false
+          }
+        ])
+
+        // Stub the calls to decodeOpReturn.
+        sandbox
+          .stub(SLP.Utils, "decodeOpReturn")
+          .onCall(0)
+          .resolves({
+            tokenType: 1,
+            transactionType: "send",
+            tokenId:
+              "f05faf13a29c7f5e54ab921750aafb6afaa953db863bd2cf432e918661d4132f",
+            spendData: [
+              {
+                quantity: "5000000",
+                sentTo:
+                  "bitcoincash:qr06e2fetka9fyh207ff3cq8xh9zfe78gyx24yadjz",
+                vout: 1
+              },
+              {
+                quantity: "395010942",
+                sentTo:
+                  "bitcoincash:qqzjzzlmx8h3hum3drsuk894jnf8r909kueykgrkk2",
+                vout: 2
+              }
+            ]
+          })
+          .onCall(1)
+          .resolves({
+            tokenType: 1,
+            transactionType: "genesis",
+            ticker: "AUDC",
+            name: "AUD Coin",
+            documentUrl: "audcoino@gmail.com",
+            documentHash: "",
+            decimals: 6,
+            mintBatonVout: 0,
+            initialQty: 2000000000000,
+            tokensSentTo:
+              "bitcoincash:qp5pup5vpdcq3qyq8f858nuqmgfq8krupvsxxuxctx",
+            batonHolder: "NEVER_CREATED"
+          })
+      }
+
       const utxos = [
         {
           txid:
@@ -1083,7 +1140,25 @@ describe("#Utils", () => {
       ]
 
       const data = await SLP.Utils.tokenUtxoDetails(utxos)
-      console.log(`data: ${JSON.stringify(data, null, 2)}`)
+      // console.log(`data: ${JSON.stringify(data, null, 2)}`)
+
+      assert2.isArray(data)
+      assert2.equal(data[0], false)
+
+      assert2.property(data[1], "txid")
+      assert2.property(data[1], "vout")
+      assert2.property(data[1], "amount")
+      assert2.property(data[1], "satoshis")
+      assert2.property(data[1], "height")
+      assert2.property(data[1], "confirmations")
+      assert2.property(data[1], "utxoType")
+      assert2.property(data[1], "tokenId")
+      assert2.property(data[1], "tokenTicker")
+      assert2.property(data[1], "tokenName")
+      assert2.property(data[1], "tokenDocumentUrl")
+      assert2.property(data[1], "tokenDocumentHash")
+      assert2.property(data[1], "decimals")
+      assert2.property(data[1], "tokenQty")
     })
   })
 })

--- a/test/Utils.js
+++ b/test/Utils.js
@@ -1059,5 +1059,31 @@ describe("#Utils", () => {
         "tokenQty"
       ])
     })
+
+    it("should process problematic utxos", async () => {
+      const utxos = [
+        {
+          txid:
+            "0e3a217fc22612002031d317b4cecd9b692b66b52951a67b23c43041aefa3959",
+          vout: 0,
+          amount: 0.00018362,
+          satoshis: 18362,
+          height: 613483,
+          confirmations: 124
+        },
+        {
+          txid:
+            "67fd3c7c3a6eb0fea9ab311b91039545086220f7eeeefa367fa28e6e43009f19",
+          vout: 1,
+          amount: 0.00000546,
+          satoshis: 546,
+          height: 612075,
+          confirmations: 1532
+        }
+      ]
+
+      const data = await SLP.Utils.tokenUtxoDetails(utxos)
+      console.log(`data: ${JSON.stringify(data, null, 2)}`)
+    })
   })
 })

--- a/test/Utils.js
+++ b/test/Utils.js
@@ -201,7 +201,7 @@ describe("#Utils", () => {
       ])
     })
 
-    it(`should fetch balances for multiple addresses.`, async () => {
+    it(`should fetch balances for multiple addresses`, async () => {
       const addresses = [
         "simpleledger:qzv3zz2trz0xgp6a96lu4m6vp2nkwag0kvyucjzqt9",
         "simpleledger:qqss4zp80hn6szsa4jg2s9fupe7g5tcg5ucdyl3r57"
@@ -210,12 +210,12 @@ describe("#Utils", () => {
       // Mock the call to rest.bitcoin.com
       if (process.env.TEST === "unit") {
         sandbox
-          .stub(axios, "get")
+          .stub(axios, "post")
           .resolves({ data: mockData.balancesForAddresses })
       }
 
       const balances = await SLP.Utils.balancesForAddress(addresses)
-      //console.log(`balances: ${JSON.stringify(balances, null, 2)}`)
+      // console.log(`balances: ${JSON.stringify(balances, null, 2)}`)
 
       assert2.isArray(balances)
       assert2.isArray(balances[0])


### PR DESCRIPTION
This PR fixes a bug that Pete discovered in tokenUtxoDetails. The bug was triggered inconsistently. It was caused by the the elements in a UTXO array getting out-of-order compared to the validatedTxid array. The changes to code fix it by using the `Array.filter` method to make sure the right array element is being selected.

The changes in this PR effect only two files. The rest are compiler noise.