### PR TITLE
Fix isTokenUtxo to non SLP transactions

### DIFF
--- a/lib/Util.js
+++ b/lib/Util.js
@@ -479,7 +479,11 @@ var Util = /** @class */ (function (_super) {
                         validations = _a.sent();
                         //console.log(`validations: ${JSON.stringify(validations,null,2)}`)
                         // Extract the boolean result
-                        validations = validations.map(function (x) { return x.valid; });
+                        validations = validations.map(function (x) {
+                            if (x !== null)
+                                return x.valid;
+                            return false;
+                        });
                         _loop_1 = function (i) {
                             var thisUtxo, thisValidation, slpData, voutMatch;
                             return __generator(this, function (_a) {

--- a/src/Util.ts
+++ b/src/Util.ts
@@ -365,7 +365,12 @@ class Util extends BITBOXUtil {
       //console.log(`validations: ${JSON.stringify(validations,null,2)}`)
 
       // Extract the boolean result
-      validations = validations.map((x: any) => x.valid)
+      validations = validations.map((x: any) => {
+        if (x !== null)
+          return x.valid;
+
+        return false;
+      })
 
       // Loop through each element and compute final validation on any that
       // returned true.


### PR DESCRIPTION
Hi :)

I found that `SLP.Utils.isTokenUtxo` does not handle validations like `SLP.Utils.tokenUtxoDetails`. More specifically, the following code of `SLP.Utils.isTokenUtxo` does not handle null cases of x:
```javascript
validations = validations.map((x: any) => x.valid)
```

I think that it should be done like in https://github.com/Bitcoin-com/slp-sdk/blob/master/src/Util.ts#L462,
correct?

By the way, thanks for your effort here at slp-sdk, it is a really helpful library!