### PR TITLE
Bug fix, TokenType1 send to many breaks in validation

### DIFF
--- a/lib/TokenType1.js
+++ b/lib/TokenType1.js
@@ -256,8 +256,11 @@ var TokenType1 = /** @class */ (function () {
         // bchChangeReceiverAddress can be either simpleledger or cashAddr format
         // validate fundingAddress format
         // single fundingAddress
-        if (config.fundingAddress && !addy.isSLPAddress(config.fundingAddress))
-            throw Error("Funding Address must be simpleledger format");
+        if (config.fundingAddress && !Array.isArray(config.fundingAddress)) {
+            if (!addy.isSLPAddress(config.fundingAddress)) {
+                throw Error("Token Receiver Address must be simpleledger format");
+            }
+        }
         // bulk fundingAddress
         if (config.fundingAddress && Array.isArray(config.fundingAddress)) {
             config.fundingAddress.forEach(function (address) {

--- a/lib/TokenType1.js
+++ b/lib/TokenType1.js
@@ -157,9 +157,7 @@ var TokenType1 = /** @class */ (function () {
                         return [2 /*return*/, sendTxid];
                     case 4:
                         utxos = [];
-                        return [4 /*yield*/, bitboxNetwork.getAllSlpBalancesAndUtxos(sendConfig.fundingAddress)
-                            // Sign and add input token UTXOs
-                        ];
+                        return [4 /*yield*/, bitboxNetwork.getAllSlpBalancesAndUtxos(sendConfig.fundingAddress)];
                     case 5:
                         balances = _a.sent();
                         tokenBalances = balances.filter(function (i) {
@@ -270,8 +268,11 @@ var TokenType1 = /** @class */ (function () {
         // validate tokenReceiverAddress format
         // single tokenReceiverAddress
         if (config.tokenReceiverAddress &&
-            !addy.isSLPAddress(config.tokenReceiverAddress))
-            throw Error("Token Receiver Address must be simpleledger format");
+            !Array.isArray(config.tokenReceiverAddress)) {
+            if (!addy.isSLPAddress(config.tokenReceiverAddress)) {
+                throw Error("Token Receiver Address must be simpleledger format");
+            }
+        }
         // bulk tokenReceiverAddress
         if (config.tokenReceiverAddress &&
             Array.isArray(config.tokenReceiverAddress)) {

--- a/src/TokenType1.ts
+++ b/src/TokenType1.ts
@@ -298,8 +298,12 @@ class TokenType1 {
     // bchChangeReceiverAddress can be either simpleledger or cashAddr format
     // validate fundingAddress format
     // single fundingAddress
-    if (config.fundingAddress && !addy.isSLPAddress(config.fundingAddress))
-      throw Error("Funding Address must be simpleledger format");
+
+    if (config.fundingAddress && !Array.isArray(config.fundingAddress)) {
+      if (!addy.isSLPAddress(config.fundingAddress)) {
+        throw Error("Token Receiver Address must be simpleledger format");
+      }
+    }
 
     // bulk fundingAddress
     if (config.fundingAddress && Array.isArray(config.fundingAddress)) {

--- a/src/TokenType1.ts
+++ b/src/TokenType1.ts
@@ -1,59 +1,59 @@
 // require deps
 // imports
-import { BITBOX } from "bitbox-sdk"
-import Address from "./Address"
+import { BITBOX } from "bitbox-sdk";
+import Address from "./Address";
 import {
   IBurnConfig,
   ICreateConfig,
   IMintConfig,
   ISendConfig
-} from "./interfaces/SLPInterfaces"
+} from "./interfaces/SLPInterfaces";
 
 // consts
-const BigNumber: any = require("bignumber.js")
-const slpjs: any = require("slpjs")
-const addy: any = new Address()
+const BigNumber: any = require("bignumber.js");
+const slpjs: any = require("slpjs");
+const addy: any = new Address();
 
 class TokenType1 {
-  restURL: string
+  restURL: string;
   constructor(restURL?: string) {
-    this.restURL = restURL
+    this.restURL = restURL;
   }
 
   async create(createConfig: ICreateConfig) {
     // validate address formats
-    this.validateAddressFormat(createConfig)
+    this.validateAddressFormat(createConfig);
 
     // determine mainnet/testnet
-    const network: string = this.returnNetwork(createConfig.fundingAddress)
+    const network: string = this.returnNetwork(createConfig.fundingAddress);
 
     // network appropriate BITBOX instance
-    const BITBOX: any = this.returnBITBOXInstance(network)
+    const BITBOX: any = this.returnBITBOXInstance(network);
 
     // slpjs BITBOX Network instance
-    const bitboxNetwork = new slpjs.BitboxNetwork(BITBOX)
+    const bitboxNetwork = new slpjs.BitboxNetwork(BITBOX);
 
-    let batonReceiverAddress: string
+    let batonReceiverAddress: string;
     if (
       createConfig.batonReceiverAddress !== undefined &&
       createConfig.batonReceiverAddress !== "" &&
       createConfig.batonReceiverAddress !== null
     )
-      batonReceiverAddress = createConfig.batonReceiverAddress
-    else batonReceiverAddress = null
+      batonReceiverAddress = createConfig.batonReceiverAddress;
+    else batonReceiverAddress = null;
 
     const balances: any = await bitboxNetwork.getAllSlpBalancesAndUtxos(
       createConfig.fundingAddress
-    )
+    );
 
-    let initialTokenQty: number = createConfig.initialTokenQty
+    let initialTokenQty: number = createConfig.initialTokenQty;
 
     initialTokenQty = new BigNumber(initialTokenQty).times(
       10 ** createConfig.decimals
-    )
+    );
     balances.nonSlpUtxos.forEach(
       (txo: any) => (txo.wif = createConfig.fundingWif)
-    )
+    );
     const genesisTxid = await bitboxNetwork.simpleTokenGenesis(
       createConfig.name,
       createConfig.symbol,
@@ -65,46 +65,46 @@ class TokenType1 {
       batonReceiverAddress,
       createConfig.bchChangeReceiverAddress,
       balances.nonSlpUtxos
-    )
-    return genesisTxid
+    );
+    return genesisTxid;
   }
 
   async mint(mintConfig: IMintConfig) {
     // validate address formats
-    this.validateAddressFormat(mintConfig)
+    this.validateAddressFormat(mintConfig);
 
     // determine mainnet/testnet
-    const network: string = this.returnNetwork(mintConfig.fundingAddress)
+    const network: string = this.returnNetwork(mintConfig.fundingAddress);
 
     // network appropriate BITBOX instance
-    const BITBOX: any = this.returnBITBOXInstance(network)
+    const BITBOX: any = this.returnBITBOXInstance(network);
 
     // slpjs BITBOX Network instance
-    const bitboxNetwork = new slpjs.BitboxNetwork(BITBOX)
+    const bitboxNetwork = new slpjs.BitboxNetwork(BITBOX);
 
     const batonReceiverAddress: string = addy.toSLPAddress(
       mintConfig.batonReceiverAddress
-    )
+    );
 
     const balances: any = await bitboxNetwork.getAllSlpBalancesAndUtxos(
       mintConfig.fundingAddress
-    )
+    );
     if (!balances.slpBatonUtxos[mintConfig.tokenId])
-      throw Error("You don't have the minting baton for this token")
+      throw Error("You don't have the minting baton for this token");
 
     const tokenInfo: any = await bitboxNetwork.getTokenInformation(
       mintConfig.tokenId
-    )
+    );
 
     const mintQty = new BigNumber(mintConfig.additionalTokenQty).times(
       10 ** tokenInfo.decimals
-    )
+    );
 
-    let inputUtxos = balances.slpBatonUtxos[mintConfig.tokenId]
+    let inputUtxos = balances.slpBatonUtxos[mintConfig.tokenId];
 
-    inputUtxos = inputUtxos.concat(balances.nonSlpUtxos)
+    inputUtxos = inputUtxos.concat(balances.nonSlpUtxos);
 
-    inputUtxos.forEach((txo: any) => (txo.wif = mintConfig.fundingWif))
+    inputUtxos.forEach((txo: any) => (txo.wif = mintConfig.fundingWif));
 
     const mintTxid = await bitboxNetwork.simpleTokenMint(
       mintConfig.tokenId,
@@ -113,58 +113,59 @@ class TokenType1 {
       mintConfig.tokenReceiverAddress,
       batonReceiverAddress,
       mintConfig.bchChangeReceiverAddress
-    )
-    return mintTxid
+    );
+    return mintTxid;
   }
 
   async send(sendConfig: ISendConfig) {
     // validate address formats
-    this.validateAddressFormat(sendConfig)
+    this.validateAddressFormat(sendConfig);
 
     // determine mainnet/testnet
-    let network: string
+    let network: string;
     if (!Array.isArray(sendConfig.fundingAddress))
-      network = this.returnNetwork(sendConfig.fundingAddress)
-    else network = this.returnNetwork(sendConfig.fundingAddress[0])
+      network = this.returnNetwork(sendConfig.fundingAddress);
+    else network = this.returnNetwork(sendConfig.fundingAddress[0]);
 
     // network appropriate BITBOX instance
-    const BITBOX: any = this.returnBITBOXInstance(network)
+    const BITBOX: any = this.returnBITBOXInstance(network);
 
     // slpjs BITBOX Network instance
-    const bitboxNetwork = new slpjs.BitboxNetwork(BITBOX)
+    const bitboxNetwork = new slpjs.BitboxNetwork(BITBOX);
 
-    const tokenId: string = sendConfig.tokenId
+    const tokenId: string = sendConfig.tokenId;
 
     const bchChangeReceiverAddress: string = addy.toSLPAddress(
       sendConfig.bchChangeReceiverAddress
-    )
+    );
 
-    const tokenInfo: any = await bitboxNetwork.getTokenInformation(tokenId)
-    const tokenDecimals: number = tokenInfo.decimals
+    const tokenInfo: any = await bitboxNetwork.getTokenInformation(tokenId);
+    const tokenDecimals: number = tokenInfo.decimals;
     if (!Array.isArray(sendConfig.fundingAddress)) {
-      let amount: any = sendConfig.amount
+      let amount: any = sendConfig.amount;
 
       const balances: any = await bitboxNetwork.getAllSlpBalancesAndUtxos(
         sendConfig.fundingAddress
-      )
+      );
 
       if (!Array.isArray(amount)) {
-        amount = new BigNumber(amount).times(10 ** tokenDecimals) // Don't forget to account for token precision
+        amount = new BigNumber(amount).times(10 ** tokenDecimals); // Don't forget to account for token precision
       } else {
         amount.forEach((amt: number, index: number) => {
-          amount[index] = new BigNumber(amt).times(10 ** tokenDecimals) // Don't forget to account for token precision
-        })
+          amount[index] = new BigNumber(amt).times(10 ** tokenDecimals); // Don't forget to account for token precision
+        });
       }
 
-      let inputUtxos = balances.slpTokenUtxos[tokenId]
+      let inputUtxos = balances.slpTokenUtxos[tokenId];
       // console.log(`inputUtxos: ${JSON.stringify(inputUtxos, null, 2)}`)
       // console.log(`balances.nonSlpUtxos: ${JSON.stringify(balances.nonSlpUtxos, null, 2)}`)
 
-      if(inputUtxos === undefined) throw new Error(`Could not find any SLP token UTXOs`)
+      if (inputUtxos === undefined)
+        throw new Error(`Could not find any SLP token UTXOs`);
 
-      inputUtxos = inputUtxos.concat(balances.nonSlpUtxos)
+      inputUtxos = inputUtxos.concat(balances.nonSlpUtxos);
 
-      inputUtxos.forEach((txo: any) => (txo.wif = sendConfig.fundingWif))
+      inputUtxos.forEach((txo: any) => (txo.wif = sendConfig.fundingWif));
 
       const sendTxid = await bitboxNetwork.simpleTokenSend(
         tokenId,
@@ -172,65 +173,63 @@ class TokenType1 {
         inputUtxos,
         sendConfig.tokenReceiverAddress,
         bchChangeReceiverAddress
-      )
-      return sendTxid
+      );
+      return sendTxid;
     }
 
-    const utxos: any[] = []
+    const utxos: any[] = [];
     const balances: any = await bitboxNetwork.getAllSlpBalancesAndUtxos(
       sendConfig.fundingAddress
-    )
+    );
 
     // Sign and add input token UTXOs
     const tokenBalances = balances.filter((i: any) => {
       try {
-        return i.result.slpTokenBalances[tokenId].isGreaterThan(0)
+        return i.result.slpTokenBalances[tokenId].isGreaterThan(0);
       } catch (_) {
-        return false
+        return false;
       }
-    })
+    });
     tokenBalances.map((i: any) =>
       i.result.slpTokenUtxos[tokenId].forEach(
         (j: any) => (j.wif = sendConfig.fundingWif[<any>i.address])
       )
-    )
+    );
     tokenBalances.forEach((a: any) => {
       try {
-        a.result.slpTokenUtxos[tokenId].forEach((txo: any) => utxos.push(txo))
+        a.result.slpTokenUtxos[tokenId].forEach((txo: any) => utxos.push(txo));
       } catch (_) {}
-    })
+    });
 
     // Sign and add input BCH (non-token) UTXOs
     const bchBalances = balances.filter(
       (i: any) => i.result.nonSlpUtxos.length > 0
-    )
+    );
     bchBalances.map((i: any) =>
       i.result.nonSlpUtxos.forEach(
         (j: any) => (j.wif = sendConfig.fundingWif[<any>i.address])
       )
-    )
+    );
     bchBalances.forEach((a: any) =>
       a.result.nonSlpUtxos.forEach((txo: any) => utxos.push(txo))
-    )
+    );
 
     utxos.forEach((txo: any) => {
       if (Array.isArray(sendConfig.fundingAddress)) {
-        sendConfig.fundingAddress.forEach(
-          (address: string, index: number) => {
-            if (txo.cashAddress === addy.toCashAddress(address))
-              txo.wif = sendConfig.fundingWif[index]
-          }
-        )
+        sendConfig.fundingAddress.forEach((address: string, index: number) => {
+          if (txo.cashAddress === addy.toCashAddress(address))
+            txo.wif = sendConfig.fundingWif[index];
+        });
       }
-    })
+    });
 
-    let amount: any = sendConfig.amount
+    let amount: any = sendConfig.amount;
     if (!Array.isArray(amount)) {
-      amount = new BigNumber(amount).times(10 ** tokenDecimals) // Don't forget to account for token precision
+      amount = new BigNumber(amount).times(10 ** tokenDecimals); // Don't forget to account for token precision
     } else {
       amount.forEach((amt: number, index: number) => {
-        amount[index] = new BigNumber(amt).times(10 ** tokenDecimals) // Don't forget to account for token precision
-      })
+        amount[index] = new BigNumber(amt).times(10 ** tokenDecimals); // Don't forget to account for token precision
+      });
     }
     return await bitboxNetwork.simpleTokenSend(
       tokenId,
@@ -238,59 +237,59 @@ class TokenType1 {
       utxos,
       sendConfig.tokenReceiverAddress,
       bchChangeReceiverAddress
-    )
+    );
   }
 
   async burn(burnConfig: IBurnConfig) {
     // validate address formats
-    this.validateAddressFormat(burnConfig)
+    this.validateAddressFormat(burnConfig);
 
     // determine mainnet/testnet
-    const network: string = this.returnNetwork(burnConfig.fundingAddress)
+    const network: string = this.returnNetwork(burnConfig.fundingAddress);
 
     // network appropriate BITBOX instance
-    const BITBOX: any = this.returnBITBOXInstance(network)
+    const BITBOX: any = this.returnBITBOXInstance(network);
 
     // slpjs BITBOX Network instance
-    const bitboxNetwork = new slpjs.BitboxNetwork(BITBOX)
+    const bitboxNetwork = new slpjs.BitboxNetwork(BITBOX);
 
     const bchChangeReceiverAddress: string = addy.toSLPAddress(
       burnConfig.bchChangeReceiverAddress
-    )
+    );
     const tokenInfo = await bitboxNetwork.getTokenInformation(
       burnConfig.tokenId
-    )
-    const tokenDecimals = tokenInfo.decimals
+    );
+    const tokenDecimals = tokenInfo.decimals;
     const balances = await bitboxNetwork.getAllSlpBalancesAndUtxos(
       burnConfig.fundingAddress
-    )
-    const amount = new BigNumber(burnConfig.amount).times(10 ** tokenDecimals)
-    let inputUtxos = balances.slpTokenUtxos[burnConfig.tokenId]
+    );
+    const amount = new BigNumber(burnConfig.amount).times(10 ** tokenDecimals);
+    let inputUtxos = balances.slpTokenUtxos[burnConfig.tokenId];
 
-    inputUtxos = inputUtxos.concat(balances.nonSlpUtxos)
+    inputUtxos = inputUtxos.concat(balances.nonSlpUtxos);
 
-    inputUtxos.forEach((txo: any) => (txo.wif = burnConfig.fundingWif))
+    inputUtxos.forEach((txo: any) => (txo.wif = burnConfig.fundingWif));
     const burnTxid = await bitboxNetwork.simpleTokenBurn(
       burnConfig.tokenId,
       amount,
       inputUtxos,
       bchChangeReceiverAddress
-    )
-    return burnTxid
+    );
+    return burnTxid;
   }
 
   returnNetwork(address: string): string {
-    return addy.detectAddressNetwork(address)
+    return addy.detectAddressNetwork(address);
   }
 
   returnBITBOXInstance(network: string): any {
-    let tmpBITBOX: any
+    let tmpBITBOX: any;
 
-    let restURL: string
-    if (network === "mainnet") restURL = "https://rest.bitcoin.com/v2/"
-    else restURL = "https://trest.bitcoin.com/v2/"
+    let restURL: string;
+    if (network === "mainnet") restURL = "https://rest.bitcoin.com/v2/";
+    else restURL = "https://trest.bitcoin.com/v2/";
 
-    return new BITBOX({ restURL: restURL })
+    return new BITBOX({ restURL: restURL });
   }
 
   validateAddressFormat(config: any): string | void {
@@ -300,23 +299,26 @@ class TokenType1 {
     // validate fundingAddress format
     // single fundingAddress
     if (config.fundingAddress && !addy.isSLPAddress(config.fundingAddress))
-      throw Error("Funding Address must be simpleledger format")
+      throw Error("Funding Address must be simpleledger format");
 
     // bulk fundingAddress
     if (config.fundingAddress && Array.isArray(config.fundingAddress)) {
       config.fundingAddress.forEach((address: string) => {
         if (!addy.isSLPAddress(address))
-          throw Error("Funding Address must be simpleledger format")
-      })
+          throw Error("Funding Address must be simpleledger format");
+      });
     }
 
     // validate tokenReceiverAddress format
     // single tokenReceiverAddress
     if (
       config.tokenReceiverAddress &&
-      !addy.isSLPAddress(config.tokenReceiverAddress)
-    )
-      throw Error("Token Receiver Address must be simpleledger format")
+      !Array.isArray(config.tokenReceiverAddress)
+    ) {
+      if (!addy.isSLPAddress(config.tokenReceiverAddress)) {
+        throw Error("Token Receiver Address must be simpleledger format");
+      }
+    }
 
     // bulk tokenReceiverAddress
     if (
@@ -325,8 +327,8 @@ class TokenType1 {
     ) {
       config.tokenReceiverAddress.forEach((address: string) => {
         if (!addy.isSLPAddress(address))
-          throw Error("Token Receiver Address must be simpleledger format")
-      })
+          throw Error("Token Receiver Address must be simpleledger format");
+      });
     }
 
     // validate bchChangeReceiverAddress format
@@ -334,15 +336,15 @@ class TokenType1 {
       config.bchChangeReceiverAddress &&
       !addy.isCashAddress(config.bchChangeReceiverAddress)
     )
-      throw Error("BCH Change Receiver Address must be cash address format")
+      throw Error("BCH Change Receiver Address must be cash address format");
 
     // validate batonReceiverAddress format
     if (
       config.batonReceiverAddress &&
       !addy.isSLPAddress(config.batonReceiverAddress)
     )
-      throw Error("Baton Receiver Address must be simpleledger format")
+      throw Error("Baton Receiver Address must be simpleledger format");
   }
 }
 
-export default TokenType1
+export default TokenType1;


### PR DESCRIPTION
Hm looks like a big change because of `prettier`, but this is actually a simple patch.

Summary of problem:
When attempting to send an `SLP.TokenType1.send` transaction to an array of SLP addresses, the error `"Invalid BCH address. Double check your address is valid: " + address);` was thrown.

This error is thrown from the `Address.prototype._ensureValidAddress` function

This was being called by the `!addy.isSLPAddress(config.tokenReceiverAddress)` condition check on line 302 of `TokenType1.ts` https://github.com/Bitcoin-com/slp-sdk/blob/master/src/TokenType1.ts#L302

This PR changes lines 302-303 to 

```
// single tokenReceiverAddress
    if (
      config.tokenReceiverAddress &&
      !Array.isArray(config.tokenReceiverAddress)
    ) {
      if (!addy.isSLPAddress(config.tokenReceiverAddress)) {
        throw Error("Token Receiver Address must be simpleledger format");
      }
    }
``` 

so that `isSLPAddress` is not called on an Array.