### PR TITLE
Multiple funding addresses for TokenType1

### DIFF
--- a/lib/TokenType1.js
+++ b/lib/TokenType1.js
@@ -140,16 +140,15 @@ var TokenType1 = /** @class */ (function () {
     };
     TokenType1.prototype.send = function (sendConfig) {
         return __awaiter(this, void 0, void 0, function () {
-            var network, BITBOX, bitboxNetwork, tokenId, bchChangeReceiverAddress, tokenInfo, tokenDecimals, amount_1, balances_1, inputUtxos, sendTxid, utxos, balances, tokenBalances, bchBalances, amount;
+            var fundingAddresses, fundingWifs, network, BITBOX, bitboxNetwork, tokenId, bchChangeReceiverAddress, tokenInfo, tokenDecimals, amount, balances, nonSlpUtxos, slpTokenUtxos, inputUtxos, sendTxid;
             return __generator(this, function (_a) {
                 switch (_a.label) {
                     case 0:
                         // validate address formats
                         this.validateAddressFormat(sendConfig);
-                        if (!Array.isArray(sendConfig.fundingAddress))
-                            network = this.returnNetwork(sendConfig.fundingAddress);
-                        else
-                            network = this.returnNetwork(sendConfig.fundingAddress[0]);
+                        fundingAddresses = [].concat(sendConfig.fundingAddress);
+                        fundingWifs = [].concat(sendConfig.fundingWif);
+                        network = this.returnNetwork(fundingAddresses[0]);
                         BITBOX = this.returnBITBOXInstance(network);
                         bitboxNetwork = new slpjs.BitboxNetwork(BITBOX);
                         tokenId = sendConfig.tokenId;
@@ -158,70 +157,10 @@ var TokenType1 = /** @class */ (function () {
                     case 1:
                         tokenInfo = _a.sent();
                         tokenDecimals = tokenInfo.decimals;
-                        if (!!Array.isArray(sendConfig.fundingAddress)) return [3 /*break*/, 4];
-                        amount_1 = sendConfig.amount;
-                        return [4 /*yield*/, bitboxNetwork.getAllSlpBalancesAndUtxos(sendConfig.fundingAddress)];
-                    case 2:
-                        balances_1 = _a.sent();
-                        if (!Array.isArray(amount_1)) {
-                            amount_1 = new BigNumber(amount_1).times(Math.pow(10, tokenDecimals)); // Don't forget to account for token precision
-                        }
-                        else {
-                            amount_1.forEach(function (amt, index) {
-                                amount_1[index] = new BigNumber(amt).times(Math.pow(10, tokenDecimals)); // Don't forget to account for token precision
-                            });
-                        }
-                        inputUtxos = balances_1.slpTokenUtxos[tokenId];
-                        // console.log(`inputUtxos: ${JSON.stringify(inputUtxos, null, 2)}`)
-                        // console.log(`balances.nonSlpUtxos: ${JSON.stringify(balances.nonSlpUtxos, null, 2)}`)
-                        if (inputUtxos === undefined)
-                            throw new Error("Could not find any SLP token UTXOs");
-                        inputUtxos = inputUtxos.concat(balances_1.nonSlpUtxos);
-                        inputUtxos.forEach(function (txo) { return (txo.wif = sendConfig.fundingWif); });
-                        return [4 /*yield*/, bitboxNetwork.simpleTokenSend(tokenId, amount_1, inputUtxos, sendConfig.tokenReceiverAddress, bchChangeReceiverAddress)];
-                    case 3:
-                        sendTxid = _a.sent();
-                        return [2 /*return*/, sendTxid];
-                    case 4:
-                        utxos = [];
-                        return [4 /*yield*/, bitboxNetwork.getAllSlpBalancesAndUtxos(sendConfig.fundingAddress)
-                            // Sign and add input token UTXOs
-                        ];
-                    case 5:
-                        balances = _a.sent();
-                        tokenBalances = balances.filter(function (i) {
-                            try {
-                                return i.result.slpTokenBalances[tokenId].isGreaterThan(0);
-                            }
-                            catch (_) {
-                                return false;
-                            }
-                        });
-                        tokenBalances.map(function (i) {
-                            return i.result.slpTokenUtxos[tokenId].forEach(function (j) { return (j.wif = sendConfig.fundingWif[i.address]); });
-                        });
-                        tokenBalances.forEach(function (a) {
-                            try {
-                                a.result.slpTokenUtxos[tokenId].forEach(function (txo) { return utxos.push(txo); });
-                            }
-                            catch (_) { }
-                        });
-                        bchBalances = balances.filter(function (i) { return i.result.nonSlpUtxos.length > 0; });
-                        bchBalances.map(function (i) {
-                            return i.result.nonSlpUtxos.forEach(function (j) { return (j.wif = sendConfig.fundingWif[i.address]); });
-                        });
-                        bchBalances.forEach(function (a) {
-                            return a.result.nonSlpUtxos.forEach(function (txo) { return utxos.push(txo); });
-                        });
-                        utxos.forEach(function (txo) {
-                            if (Array.isArray(sendConfig.fundingAddress)) {
-                                sendConfig.fundingAddress.forEach(function (address, index) {
-                                    if (txo.cashAddress === addy.toCashAddress(address))
-                                        txo.wif = sendConfig.fundingWif[index];
-                                });
-                            }
-                        });
                         amount = sendConfig.amount;
+                        return [4 /*yield*/, bitboxNetwork.getAllSlpBalancesAndUtxos(fundingAddresses)];
+                    case 2:
+                        balances = _a.sent();
                         if (!Array.isArray(amount)) {
                             amount = new BigNumber(amount).times(Math.pow(10, tokenDecimals)); // Don't forget to account for token precision
                         }
@@ -230,21 +169,30 @@ var TokenType1 = /** @class */ (function () {
                                 amount[index] = new BigNumber(amt).times(Math.pow(10, tokenDecimals)); // Don't forget to account for token precision
                             });
                         }
-                        return [4 /*yield*/, bitboxNetwork.simpleTokenSend(tokenId, amount, utxos, sendConfig.tokenReceiverAddress, bchChangeReceiverAddress)];
-                    case 6: return [2 /*return*/, _a.sent()];
+                        nonSlpUtxos = balances.reduce(function (previousNonSlpUtxos, currentBalance, index) { return __spreadArrays(previousNonSlpUtxos, currentBalance.result.nonSlpUtxos.map(function (utxo) { return (__assign(__assign({}, utxo), { wif: fundingWifs[index] })); })); }, []);
+                        slpTokenUtxos = balances.reduce(function (previousSlpTokenUtxos, currentBalance, index) { return __spreadArrays(previousSlpTokenUtxos, (currentBalance.result.slpTokenUtxos[tokenId] || []).map(function (utxo) { return (__assign(__assign({}, utxo), { wif: fundingWifs[index] })); })); }, []);
+                        if (slpTokenUtxos.length === 0)
+                            throw new Error("Could not find any SLP token UTXOs");
+                        inputUtxos = __spreadArrays(nonSlpUtxos, slpTokenUtxos);
+                        return [4 /*yield*/, bitboxNetwork.simpleTokenSend(tokenId, amount, inputUtxos, sendConfig.tokenReceiverAddress, bchChangeReceiverAddress)];
+                    case 3:
+                        sendTxid = _a.sent();
+                        return [2 /*return*/, sendTxid];
                 }
             });
         });
     };
     TokenType1.prototype.burn = function (burnConfig) {
         return __awaiter(this, void 0, void 0, function () {
-            var network, BITBOX, bitboxNetwork, bchChangeReceiverAddress, tokenInfo, tokenDecimals, balances, amount, inputUtxos, burnTxid;
+            var fundingAddresses, fundingWifs, network, BITBOX, bitboxNetwork, bchChangeReceiverAddress, tokenInfo, tokenDecimals, balances, amount, nonSlpUtxos, slpTokenUtxos, inputUtxos, burnTxid;
             return __generator(this, function (_a) {
                 switch (_a.label) {
                     case 0:
                         // validate address formats
                         this.validateAddressFormat(burnConfig);
-                        network = this.returnNetwork(burnConfig.fundingAddress[0]);
+                        fundingAddresses = [].concat(burnConfig.fundingAddress);
+                        fundingWifs = [].concat(burnConfig.fundingWif);
+                        network = this.returnNetwork(fundingAddresses[0]);
                         BITBOX = this.returnBITBOXInstance(network);
                         bitboxNetwork = new slpjs.BitboxNetwork(BITBOX);
                         bchChangeReceiverAddress = addy.toSLPAddress(burnConfig.bchChangeReceiverAddress);
@@ -252,13 +200,13 @@ var TokenType1 = /** @class */ (function () {
                     case 1:
                         tokenInfo = _a.sent();
                         tokenDecimals = tokenInfo.decimals;
-                        return [4 /*yield*/, bitboxNetwork.getAllSlpBalancesAndUtxos(burnConfig.fundingAddress)];
+                        return [4 /*yield*/, bitboxNetwork.getAllSlpBalancesAndUtxos(fundingAddresses)];
                     case 2:
                         balances = _a.sent();
                         amount = new BigNumber(burnConfig.amount).times(Math.pow(10, tokenDecimals));
-                        inputUtxos = balances.slpTokenUtxos[burnConfig.tokenId];
-                        inputUtxos = inputUtxos.concat(balances.nonSlpUtxos);
-                        inputUtxos.forEach(function (txo) { return (txo.wif = burnConfig.fundingWif); });
+                        nonSlpUtxos = balances.reduce(function (previousNonSlpUtxos, currentBalance, index) { return __spreadArrays(previousNonSlpUtxos, currentBalance.result.nonSlpUtxos.map(function (utxo) { return (__assign(__assign({}, utxo), { wif: fundingWifs[index] })); })); }, []);
+                        slpTokenUtxos = balances.reduce(function (previousSlpTokenUtxos, currentBalance, index) { return __spreadArrays(previousSlpTokenUtxos, (currentBalance.result.slpTokenUtxos[burnConfig.tokenId] || []).map(function (utxo) { return (__assign(__assign({}, utxo), { wif: fundingWifs[index] })); })); }, []);
+                        inputUtxos = __spreadArrays(nonSlpUtxos, slpTokenUtxos);
                         return [4 /*yield*/, bitboxNetwork.simpleTokenBurn(burnConfig.tokenId, amount, inputUtxos, bchChangeReceiverAddress)];
                     case 3:
                         burnTxid = _a.sent();

--- a/lib/TokenType1.js
+++ b/lib/TokenType1.js
@@ -1,4 +1,15 @@
 "use strict";
+var __assign = (this && this.__assign) || function () {
+    __assign = Object.assign || function(t) {
+        for (var s, i = 1, n = arguments.length; i < n; i++) {
+            s = arguments[i];
+            for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
+                t[p] = s[p];
+        }
+        return t;
+    };
+    return __assign.apply(this, arguments);
+};
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
@@ -35,6 +46,13 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
         if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
     }
 };
+var __spreadArrays = (this && this.__spreadArrays) || function () {
+    for (var s = 0, i = 0, il = arguments.length; i < il; i++) s += arguments[i].length;
+    for (var r = Array(s), k = 0, i = 0; i < il; i++)
+        for (var a = arguments[i], j = 0, jl = a.length; j < jl; j++, k++)
+            r[k] = a[j];
+    return r;
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 // require deps
 // imports
@@ -50,13 +68,15 @@ var TokenType1 = /** @class */ (function () {
     }
     TokenType1.prototype.create = function (createConfig) {
         return __awaiter(this, void 0, void 0, function () {
-            var network, BITBOX, bitboxNetwork, batonReceiverAddress, balances, initialTokenQty, genesisTxid;
+            var fundingAddresses, fundingWifs, network, BITBOX, bitboxNetwork, batonReceiverAddress, balances, initialTokenQty, nonSlpUtxos, genesisTxid;
             return __generator(this, function (_a) {
                 switch (_a.label) {
                     case 0:
                         // validate address formats
                         this.validateAddressFormat(createConfig);
-                        network = this.returnNetwork(createConfig.fundingAddress);
+                        fundingAddresses = [].concat(createConfig.fundingAddress);
+                        fundingWifs = [].concat(createConfig.fundingWif);
+                        network = this.returnNetwork(fundingAddresses[0]);
                         BITBOX = this.returnBITBOXInstance(network);
                         bitboxNetwork = new slpjs.BitboxNetwork(BITBOX);
                         if (createConfig.batonReceiverAddress !== undefined &&
@@ -65,13 +85,13 @@ var TokenType1 = /** @class */ (function () {
                             batonReceiverAddress = createConfig.batonReceiverAddress;
                         else
                             batonReceiverAddress = null;
-                        return [4 /*yield*/, bitboxNetwork.getAllSlpBalancesAndUtxos(createConfig.fundingAddress)];
+                        return [4 /*yield*/, bitboxNetwork.getAllSlpBalancesAndUtxos(fundingAddresses)];
                     case 1:
                         balances = _a.sent();
                         initialTokenQty = createConfig.initialTokenQty;
                         initialTokenQty = new BigNumber(initialTokenQty).times(Math.pow(10, createConfig.decimals));
-                        balances.nonSlpUtxos.forEach(function (txo) { return (txo.wif = createConfig.fundingWif); });
-                        return [4 /*yield*/, bitboxNetwork.simpleTokenGenesis(createConfig.name, createConfig.symbol, initialTokenQty, createConfig.documentUri, createConfig.documentHash, createConfig.decimals, createConfig.tokenReceiverAddress, batonReceiverAddress, createConfig.bchChangeReceiverAddress, balances.nonSlpUtxos)];
+                        nonSlpUtxos = balances.reduce(function (previousNonSlpUtxos, currentBalance, index) { return __spreadArrays(previousNonSlpUtxos, currentBalance.result.nonSlpUtxos.map(function (utxo) { return (__assign(__assign({}, utxo), { wif: fundingWifs[index] })); })); }, []);
+                        return [4 /*yield*/, bitboxNetwork.simpleTokenGenesis(createConfig.name, createConfig.symbol, initialTokenQty, createConfig.documentUri, createConfig.documentHash, createConfig.decimals, createConfig.tokenReceiverAddress, batonReceiverAddress, createConfig.bchChangeReceiverAddress, nonSlpUtxos)];
                     case 2:
                         genesisTxid = _a.sent();
                         return [2 /*return*/, genesisTxid];
@@ -81,28 +101,35 @@ var TokenType1 = /** @class */ (function () {
     };
     TokenType1.prototype.mint = function (mintConfig) {
         return __awaiter(this, void 0, void 0, function () {
-            var network, BITBOX, bitboxNetwork, batonReceiverAddress, balances, tokenInfo, mintQty, inputUtxos, mintTxid;
+            var fundingAddresses, fundingWifs, network, BITBOX, bitboxNetwork, batonReceiverAddress, balances, balanceWithBaton, tokenInfo, mintQty, nonSlpUtxos, slpBatonUtxos, inputUtxos, mintTxid;
             return __generator(this, function (_a) {
                 switch (_a.label) {
                     case 0:
                         // validate address formats
                         this.validateAddressFormat(mintConfig);
-                        network = this.returnNetwork(mintConfig.fundingAddress);
+                        fundingAddresses = [].concat(mintConfig.fundingAddress);
+                        fundingWifs = [].concat(mintConfig.fundingWif);
+                        network = this.returnNetwork(fundingAddresses[0]);
                         BITBOX = this.returnBITBOXInstance(network);
                         bitboxNetwork = new slpjs.BitboxNetwork(BITBOX);
                         batonReceiverAddress = addy.toSLPAddress(mintConfig.batonReceiverAddress);
-                        return [4 /*yield*/, bitboxNetwork.getAllSlpBalancesAndUtxos(mintConfig.fundingAddress)];
+                        return [4 /*yield*/, bitboxNetwork.getAllSlpBalancesAndUtxos(fundingAddresses)];
                     case 1:
                         balances = _a.sent();
-                        if (!balances.slpBatonUtxos[mintConfig.tokenId])
+                        balanceWithBaton = balances
+                            .find(function (balance) { return balance.result.slpBatonUtxos[mintConfig.tokenId]; });
+                        if (!balanceWithBaton)
                             throw Error("You don't have the minting baton for this token");
                         return [4 /*yield*/, bitboxNetwork.getTokenInformation(mintConfig.tokenId)];
                     case 2:
                         tokenInfo = _a.sent();
                         mintQty = new BigNumber(mintConfig.additionalTokenQty).times(Math.pow(10, tokenInfo.decimals));
-                        inputUtxos = balances.slpBatonUtxos[mintConfig.tokenId];
-                        inputUtxos = inputUtxos.concat(balances.nonSlpUtxos);
-                        inputUtxos.forEach(function (txo) { return (txo.wif = mintConfig.fundingWif); });
+                        nonSlpUtxos = balances.reduce(function (previousNonSlpUtxos, currentBalance, index) { return __spreadArrays(previousNonSlpUtxos, currentBalance.result.nonSlpUtxos.map(function (utxo) { return (__assign(__assign({}, utxo), { wif: fundingWifs[index] })); })); }, []);
+                        slpBatonUtxos = balanceWithBaton
+                            .result
+                            .slpBatonUtxos[mintConfig.tokenId]
+                            .map(function (utxo) { return (__assign(__assign({}, utxo), { wif: fundingWifs[balances.indexOf(balanceWithBaton)] })); });
+                        inputUtxos = __spreadArrays(nonSlpUtxos, slpBatonUtxos);
                         return [4 /*yield*/, bitboxNetwork.simpleTokenMint(mintConfig.tokenId, mintQty, inputUtxos, mintConfig.tokenReceiverAddress, batonReceiverAddress, mintConfig.bchChangeReceiverAddress)];
                     case 3:
                         mintTxid = _a.sent();
@@ -217,7 +244,7 @@ var TokenType1 = /** @class */ (function () {
                     case 0:
                         // validate address formats
                         this.validateAddressFormat(burnConfig);
-                        network = this.returnNetwork(burnConfig.fundingAddress);
+                        network = this.returnNetwork(burnConfig.fundingAddress[0]);
                         BITBOX = this.returnBITBOXInstance(network);
                         bitboxNetwork = new slpjs.BitboxNetwork(BITBOX);
                         bchChangeReceiverAddress = addy.toSLPAddress(burnConfig.bchChangeReceiverAddress);
@@ -257,9 +284,6 @@ var TokenType1 = /** @class */ (function () {
         // fundingAddress, tokenReceiverAddress and batonReceiverAddress must be simpleledger format
         // bchChangeReceiverAddress can be either simpleledger or cashAddr format
         // validate fundingAddress format
-        // single fundingAddress
-        if (config.fundingAddress && !addy.isSLPAddress(config.fundingAddress))
-            throw Error("Funding Address must be simpleledger format");
         // bulk fundingAddress
         if (config.fundingAddress && Array.isArray(config.fundingAddress)) {
             config.fundingAddress.forEach(function (address) {
@@ -267,6 +291,8 @@ var TokenType1 = /** @class */ (function () {
                     throw Error("Funding Address must be simpleledger format");
             });
         }
+        else if (!config.fundingAddress || !addy.isSLPAddress(config.fundingAddress))
+            throw Error("Funding Address must be simpleledger format");
         // validate tokenReceiverAddress format
         // single tokenReceiverAddress
         if (config.tokenReceiverAddress &&

--- a/src/interfaces/SLPInterfaces.ts
+++ b/src/interfaces/SLPInterfaces.ts
@@ -4,8 +4,8 @@ export interface IConfig {
 }
 
 export interface ICreateConfig {
-  fundingAddress: string
-  fundingWif: string
+  fundingAddress: string | string[]
+  fundingWif: string | string[]
   tokenReceiverAddress: string
   batonReceiverAddress: string
   bchChangeReceiverAddress: string
@@ -18,8 +18,8 @@ export interface ICreateConfig {
 }
 
 export interface IMintConfig {
-  fundingAddress: string
-  fundingWif: string
+  fundingAddress: string | string[]
+  fundingWif: string | string[]
   tokenReceiverAddress: string
   batonReceiverAddress: string
   bchChangeReceiverAddress: string
@@ -37,8 +37,8 @@ export interface ISendConfig {
 }
 
 export interface IBurnConfig {
-  fundingAddress: string
-  fundingWif: string
+  fundingAddress: string | string[]
+  fundingWif: string | string[]
   tokenId: string
   bchChangeReceiverAddress: string
   amount: number


### PR DESCRIPTION
Hi there,

As already suggested at https://github.com/Bitcoin-com/slp-sdk/issues/30, TokenType1 operations currently only support a single funding address for some operations. The problem is there are scenarios where supporting multiple funding addresses is necessary. As an example:

Suppose a client wallet wants to implement https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki to support BCH at the derivation path m/44'/145' and SLP tokens at the derivation path m/44'/245'. A TokenType1.mint operation will need some "BCH
utxos" (from path m/44'/145') and the "baton utxo" (from path m/44'/245'), but currently, slp-sdk will try to get all utxos from a single funding address.

This PR implements multiple funding addresses to all TokenType1 operations, although maybe not all operations may need it. What do you think? It makes sense to implement multiple funding addresses in all operations or the above scenario should be done using something like https://github.com/simpleledger/slpjs directly?
